### PR TITLE
Call lerna using npx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents
+npx lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents


### PR DESCRIPTION
Lerna might not always be available in the executable path, call it via npx instead.