### PR TITLE
fix(docs): auth codeblocks

### DIFF
--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/apple.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/apple.mdx
@@ -94,9 +94,9 @@ After signing in, the user will be redirected back to your app.<br />
 To begin authenticating with Apple you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/apple' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/apple'
 ```
+
 ``` json title="Response"
 {
     "result": "https://appleid.apple.com/auth/authorize?client_id=io.conduit.app&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthentication%2Fapple%2Fcallback&response_type=code%20id_token&response_mode=form_post&scope=name%20email&state=eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U&nonce=eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/bitbucket.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/bitbucket.mdx
@@ -29,8 +29,7 @@ Then, fill the required fields you obtained from the Bitbucket App.
 To begin authenticating with Bitbucket you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/bitbucket' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/bitbucket'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/facebook.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/facebook.mdx
@@ -50,8 +50,7 @@ Then, fill the required fields you obtained from the Facebook App.
 To begin authenticating with Facebook you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/facebook' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/facebook'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/figma.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/figma.mdx
@@ -33,8 +33,7 @@ Then, fill the required fields you obtained from the Figma App.
 To begin authenticating with Figma you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/figma' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/figma'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/github.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/github.mdx
@@ -40,8 +40,7 @@ Then, fill the required fields you obtained from the GitHub App.
 To begin authenticating with GitHub you request a redirect url with the proper scopes<br />
 
 ```bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/github' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTgwMjc0MCwiZXhwIjoxNjY5ODc0NzQwfQ._Q5rzo-FJ7gLesdaKV13dXi9aMNpGZA_nGpNJfkov3Y'
+curl --location --request GET 'http://localhost:3000/authentication/init/github'
 ```
 
 ```json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/gitlab.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/gitlab.mdx
@@ -35,9 +35,9 @@ Then, fill the required fields you obtained from the GitLab App.
 To begin authenticating with GitLab you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/gitlab' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U' \
+curl --location --request GET 'http://localhost:3000/authentication/init/gitlab'
 ```
+
 ``` json title="Response"
 {
     "result": "https://gitlab.com/oauth/authorize?client_id=1&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthentication%2Fcallback%2Fgitlab&response_type=code&scope=read_user+read_api+read_repository+openid+profile+email&state=eyJpZCI6IjYzN

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/google.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/google.mdx
@@ -41,8 +41,7 @@ A pop-up window will be displayed to you which contain your client id and client
 To begin authenticating with Google you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/google' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/init/google'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/linkedIn.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/linkedIn.mdx
@@ -35,8 +35,7 @@ Then, fill the required fields you obtained from the LinkedIn App.
 To begin authenticating with LinkedIn you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/linkedin' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/linkedin'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/microsoft.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/microsoft.mdx
@@ -35,8 +35,7 @@ Select the Microsoft provider and enter the following details:
 To begin authenticating with Microsoft you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/microsoft' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U' \
+curl --location --request GET 'http://localhost:3000/authentication/init/microsoft'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/reddit.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/reddit.mdx
@@ -27,8 +27,7 @@ Then, fill the required fields you obtained from the Reddit App.
 To begin authenticating with Reddit you request a redirect url with the proper scopes<br />
 
 ```bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/reddit' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTcyODgwOCwiZXhwIjoxNjY5ODAwODA4fQ._bHzQ7t2NuOiupEbWX25R_jCShev8Av3PSZW5mOPlaI'
+curl --location --request GET 'http://localhost:3000/authentication/init/reddit'
 ```
 
 ```json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/slack.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/slack.mdx
@@ -35,9 +35,9 @@ Then, fill the required fields you obtained from the Slack App.
 To begin authenticating with Slack you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/slack' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U'
+curl --location --request GET 'http://localhost:3000/authentication/init/slack'
 ```
+
 ``` json title="Response"
 {
   "result": "https://slack.com/oauth/v2/authorize?client_id=1234567890.1234567890&scope=identity.basic&redirect_uri=http://localhost:3000/authentication/callback/slack&state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/twitch.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/twitch.mdx
@@ -27,9 +27,7 @@ Then, fill the required fields you obtained from the Twitch App.
 To begin authenticating with Twitch you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/twitch' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U' \
-
+curl --location --request GET 'http://localhost:3000/authentication/init/twitch'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/twitter.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/OAuth2/twitter.mdx
@@ -37,8 +37,7 @@ If you don't have a Twitter app, you can create one [here](https://developer.twi
 To begin authenticating with Twitter you request a redirect url with the proper scopes<br />
 
 ``` bash title="Request"
-curl --location --request GET 'http://localhost:3000/authentication/init/twitter' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTIxMDM1MywiZXhwIjoxNjY5MjgyMzUzfQ.TyvHCuyDKLiKFoEpaXRdbYoFwrzDlFiW4VdUVQJdf7U' \
+curl --location --request GET 'http://localhost:3000/authentication/init/twitter'
 ```
 
 ``` bash title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/captcha.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/captcha.mdx
@@ -33,12 +33,12 @@ Let's make a login request using the [local authentication strategy](./local).
 
 ``` bash title="Request"
 curl --location --request POST 'http://localhost:3000/authentication/local' \
---header 'Content-Type: application/json' \
---data-raw '{
-"email": "example@mail.com",
-"password": "I_h4t3_p4ss_r3qu1r3m3nts",
-"captchaToken": "10000000-aaaa-bbbb-cccc-000000000001",  //hcaptcha test token
-}'
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "email": "example@mail.com",
+    "password": "I_h4t3_p4ss_r3qu1r3m3nts",
+    "captchaToken": "10000000-aaaa-bbbb-cccc-000000000001",
+  }'
 ```
 
 ``` json title="Response"

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/local.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/local.mdx
@@ -21,11 +21,11 @@ The Authentication module can then be used to verify the JWT token and retrieve 
 
 ``` bash title="Request"
 curl --location --request POST 'http://localhost:3000/authentication/local' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "email": "example@mail.com",
-        "password": "I_h4t3_p4ss_r3qu1r3m3nts"
-      } '
+     --header 'Content-Type: application/json' \
+     --data-raw '{
+     "email": "example@mail.com",
+     "password": "I_h4t3_p4ss_r3qu1r3m3nts"
+     } '
 ```
 ``` json title="Response"
 {
@@ -42,11 +42,11 @@ Send a `POST` request to `/authentication/local`, passing in your user credentia
 
 ``` bash title="Request"
 curl --location --request POST 'http://localhost:3000/authentication/local' \
-      --header 'Content-Type: application/json' \
-      --data-raw '{
-        "email": "example@mail.com",
-        "password": "I_h4t3_p4ss_r3qu1r3m3nts"
-      }'
+     --header 'Content-Type: application/json' \
+     --data-raw '{
+     "email": "example@mail.com",
+     "password": "I_h4t3_p4ss_r3qu1r3m3nts"
+     }'
 ```
 ``` json title="Response"
 {
@@ -73,11 +73,8 @@ Meaning you can't reuse or refresh tokens across different clients.
 Let's finish off with an example on how to do just that.
 
 ``` bash title="Request"
-curl --location --request POST 'http://localhost:3000/authentication/renew' \
---header 'Authorization: Bearer YlwPQv1SvYY4um4G75zZfr5BBqwTx8rp0PsLtpLBmcqywnriAb06oF/luec0iyzCAZu1ftwQ/WZq+v/DHO+XJw==' \
---header 'Content-Type: application/json'
+curl --location --request POST 'http://localhost:3000/authentication/renew'
 ```
-
 
 ``` json title="Response"
 {
@@ -95,11 +92,11 @@ curl --location --request POST 'http://localhost:3000/authentication/renew' \
 # Used to resend email verification after new user is created.
 
 curl --location --request POST 'http://localhost:3000/authentication/local/resent-verification' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---data-raw '{
-  "email": "example@mail.com"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --data-raw '{
+       "email": "example@mail.com"
+     }'
 ```
 
 ## Forgot Password
@@ -108,11 +105,11 @@ curl --location --request POST 'http://localhost:3000/authentication/local/resen
 # Generates a password reset token and forwards a verification link to the user's email address.
 
 curl --location --request POST 'http://localhost:3000/authentication/forgot-password' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---data-raw '{
-  "email": "example@mail.com"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --data-raw '{
+       "email": "example@mail.com"
+     }'
 ```
 
 ## Reset Password
@@ -124,12 +121,12 @@ curl --location --request POST 'http://localhost:3000/authentication/forgot-pass
 # New password must not be the same as the old password.
 
 curl --location --request POST 'http://localhost:3000/authentication/reset-password' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---data-raw '{
-  "passwordResetToken": "passwordResetToken",
-  "password": "pass"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --data-raw '{
+       "passwordResetToken": "passwordResetToken",
+       "password": "pass"
+     }'
 ```
 
 
@@ -143,13 +140,13 @@ curl --location --request POST 'http://localhost:3000/authentication/reset-passw
 # The new password can not be the same as the old password
 
 curl --location --request POST 'http:/localhost:3000/authentication/local/change-password' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTk4MTIwOSwiZXhwIjoxNjcwMDUzMjA5fQ.sxIQDgJv5zzZo8PV6logbvyLO0WbXgES9EWEtUo_kEg' \
---data-raw '{
-  "oldPassword": "your_old_password",
-  "newPassword": "your_new_password"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTk4MTIwOSwiZXhwIjoxNjcwMDUzMjA5fQ.sxIQDgJv5zzZo8PV6logbvyLO0WbXgES9EWEtUo_kEg' \
+     --data-raw '{
+       "oldPassword": "your_old_password",
+       "newPassword": "your_new_password"
+     }'
 ```
 
 ## Change Email
@@ -161,12 +158,12 @@ curl --location --request POST 'http:/localhost:3000/authentication/local/change
 # The new email can not be the same as the old email
 
 curl --location --request POST 'http://localhost:3000/authentication/local/change-email' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTk4MTIwOSwiZXhwIjoxNjcwMDUzMjA5fQ.sxIQDgJv5zzZo8PV6logbvyLO0WbXgES9EWEtUo_kEg' \
---data-raw '{
-  "newEmail": "newEMail@mail.com"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTk4MTIwOSwiZXhwIjoxNjcwMDUzMjA5fQ.sxIQDgJv5zzZo8PV6logbvyLO0WbXgES9EWEtUo_kEg' \
+     --data-raw '{
+       "newEmail": "newEMail@mail.com"
+     }'
 ```
 
 ## Verify Email
@@ -174,8 +171,7 @@ curl --location --request POST 'http://localhost:3000/authentication/local/chang
 ```bash title=" Verify Email Request"
 # A webhook used to verify user email. This bypasses the need for client id/secret.
 
-curl --location --request GET 'http://localhost:3000/hook/authentication/verify-email/:verificationToken' \
---header 'Accept: application/json'
+curl --location --request GET 'http://localhost:3000/hook/authentication/verify-email/:verificationToken'
 ```
 
 ## Verify Change Email
@@ -184,9 +180,7 @@ curl --location --request GET 'http://localhost:3000/hook/authentication/verify-
 
 # A webhook used to verify an email address change. This bypasses the need for client id/secret.
 
-curl --location --request GET 'http://localhost:3000/hook/authentication/verify-change-email/:verificationToken' \
---header 'Accept: application/json'
-
+curl --location --request GET 'http://localhost:3000/hook/authentication/verify-change-email/:verificationToken'
 ```
 
 ## Logout
@@ -195,8 +189,8 @@ curl --location --request GET 'http://localhost:3000/hook/authentication/verify-
 # logs out authenticated user and removes cookies
 
 curl --location --request POST 'http://localhost:3000/authentication/logout' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTk4MTIwOSwiZXhwIjoxNjcwMDUzMjA5fQ.sxIQDgJv5zzZo8PV6logbvyLO0WbXgES9EWEtUo_kEg' \
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTk4MTIwOSwiZXhwIjoxNjcwMDUzMjA5fQ.sxIQDgJv5zzZo8PV6logbvyLO0WbXgES9EWEtUo_kEg'
 }'
 ```

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/twoFa.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/twoFa.mdx
@@ -19,15 +19,14 @@ The sms parameter is required for the `sms` method and is the phone number that 
 
 
 ```bash title="Enable two factor authentication with phone method"
-curl -X PUT \
-  http://localhost:3000/authentication/twoFa/enable \
-  -H 'Content-Type: application/json' \
-  -H 'accept: application/json' \
-  -H 'Authorization: Bearer {{token}}' \
-  -d '{
-  "method": "sms",
-  "phone": "1234567890"
-}'
+curl -X PUT 'http://localhost:3000/authentication/twoFa/enable' \
+     -H 'Content-Type: application/json' \
+     -H 'accept: application/json' \
+     -H 'Authorization: Bearer {{token}}' \
+     -d '{
+       "method": "sms",
+       "phone": "1234567890"
+     }'
 ```
 ```json title="Responsee"
 {
@@ -39,13 +38,12 @@ If a user wants to enable 2FA using the Authenticator method, they can use the f
 ```bash title="Enable two factor authentication with authenticator method"
 
 curl --location --request PUT 'http://localhost:3000/authentication/twoFa/enable' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer ' \
---data-raw '{
-  "method": "authenticator"
-}'
-
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer ' \
+     --data-raw '{
+       "method": "authenticator"
+     }'
 ```
 The response will be a link to a QR code that can be scanned by an authenticator app.
 
@@ -60,12 +58,12 @@ That is done by using the following curl example:
 
 ```bash title="Verify two factor authentication code"
 curl --location --request POST 'http://localhost:3000/authentication/twoFa/enable/verify' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer ' \
---data-raw '{
-  "code": "488333"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer ' \
+     --data-raw '{
+       "code": "488333"
+     }'
 ```
 After a successful verification, the user will be able to use 2FA to login.
 
@@ -86,12 +84,10 @@ From now on, the endpoint that they will use to log in is the following:
 # User's 2FA mechanism has to be enabled.
 
 curl -X POST http://localhost:3000/authentication/twoFa/authorize \
--H 'Content-Type: application/json' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw' \
-
-
+     -H 'Content-Type: application/json' \
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw'
 ```
 If the user has enabled 2FA with a sms method the response will be like this:
 ```json title="Response"
@@ -126,13 +122,12 @@ A curl example of the endpoint that verifies the code is shown below:
 ```bash title="Verify two factor authentication code"
 
 curl --location --request POST 'http://localhost:3000/authentication/twoFa/verify' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw' \
---data-raw '{
-    "code": "123456"
-}'
-
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw' \
+     --data-raw '{
+         "code": "123456"
+     }'
 ```
 
 After a successful verification, access and refresh tokens will be returned.
@@ -151,9 +146,8 @@ If a user has no access to their phone or authenticator app, they can use the ba
 
 ```bash title="Generate backup codes"
 curl --location --request GET 'http://localhost:3000/authentication/twoFa/generate' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer ' \
-
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw'
 ```
 This will return a set of 10 backup codes that the user can use to log in.
 
@@ -185,12 +179,12 @@ A curl example is shown below:
 
 ```bash title="Recover two factor authentication"
 curl --location --request POST 'http://localhost:3000/authentication/twoFa/recover' \
---header 'Content-Type: application/json' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer ' \
---data-raw '{
-  "code": "38923664"
-}'
+     --header 'Content-Type: application/json' \
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw' \
+     --data-raw '{
+       "code": "38923664"
+     }'
 ```
 After successfully recovering 2FA, access and refresh tokens are returned as well as a message that informs the user about remaining back-up codes.
 
@@ -202,8 +196,6 @@ After successfully recovering 2FA, access and refresh tokens are returned as wel
 }
 ```
 
-
-
 ###  Disable two-factor authentication
 
 A user can disable 2FA any time they want. This will remove the 2FA method and the user will be able to log in without a code.<br />
@@ -212,9 +204,8 @@ A user can disable 2FA any time they want. This will remove the 2FA method and t
 
 ```bash title="Disable two factor authentication"
 curl --location --request PUT 'http://localhost:3000/authentication/twoFa/disable' \
---header 'Accept: application/json' \
---header 'Authorization: Bearer {{token}}' \
-
+     --header 'Accept: application/json' \
+     --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjNjZGNkMDhkNTU2MDk1NmM4MGQ4OSIsImlhdCI6MTY2OTkwODA2MCwiZXhwIjoxNjY5OTgwMDYwfQ.9dtBJc4YvSbuz74YRhJj4b9k-myAC_6EPlVFunRMkcw'
 ```
 After successfully disabling 2FA, the following message is returned:
 
@@ -223,10 +214,3 @@ After successfully disabling 2FA, the following message is returned:
     "message": "2FA disabled"
 }
 ```
-
-
-
-
-
-
-

--- a/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/twoFa.mdx
+++ b/documentation/versioned_docs/version-v0.15/modules/authentication/tutorials/twoFa.mdx
@@ -153,7 +153,7 @@ This will return a set of 10 backup codes that the user can use to log in.
 
 ```json title="Response"
 {
-    [
+    "codes": [
         "3892 3664",
         "3676 4634",
         "5810 6001",
@@ -168,10 +168,10 @@ This will return a set of 10 backup codes that the user can use to log in.
 }
 ```
 :::caution
-**This codes must be stored in a safe place and the user must be informed that they can only be used once.**
+**These codes must be stored in a safe place and the user must be informed that they can only be used once.**
 :::
 
-### Revover access with backup codes
+### Recover access with backup codes
 
 This endpoint is used to recover 2FA access with an 8 digit backup code.<br />
 A user can use one of the backup codes that were generated in the previous step.


### PR DESCRIPTION
This PR cleans up auth doc codeblocks, removing copy-pasted authorization headers in login-related examples, adding example auth headers where they were missing etc.
Removed a codeblock comment as that would produce an error if a user were to copy-paste it as is.
Formatted codeblock spacing.
Removed line continuation backslashes with no followup line.
Fixed a couple of typos and a missing object field.

**What kind of change does this PR introduce?** <!--(check at least one)-->

- [X] Bugfix
- [ ] Feature
- [X] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** <!-- (check one) -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications. -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's description  (e.g. `fix #xxx`, where "xxx" is the issue number)